### PR TITLE
ROC-2760: Add custom object mapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.0.7'
+version '1.0.8'
 
 checkstyle {
     maxWarnings = 0
@@ -114,6 +114,7 @@ bintray {
 
 ext {
     lombokVersion = '1.16.18'
+    jacksonVersion = '2.8.10'
 }
 
 dependencies {
@@ -121,6 +122,11 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
     compile group: 'io.github.openfeign', name: 'feign-httpclient', version: '9.5.0'
     compile group: 'com.netflix.feign', name: 'feign-jackson', version: '8.18.0'
+    
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
+    compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names', version: jacksonVersion
+    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: jacksonVersion
+    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: jacksonVersion
 
     compileOnly group: 'org.projectlombok', name: 'lombok', version: lombokVersion
     apt group: 'org.projectlombok', name: 'lombok', version: lombokVersion

--- a/src/main/java/uk/gov/hmcts/reform/ccd/client/CoreCaseDataApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/client/CoreCaseDataApi.java
@@ -1,5 +1,11 @@
 package uk.gov.hmcts.reform.ccd.client;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import feign.codec.Decoder;
 import feign.jackson.JacksonDecoder;
 import org.springframework.cloud.netflix.feign.FeignClient;
@@ -65,7 +71,16 @@ public interface CoreCaseDataApi {
         @Primary
         @Scope("prototype")
         Decoder feignDecoder() {
-            return new JacksonDecoder();
+            return new JacksonDecoder(objectMapper());
+        }
+
+        @Bean
+        public ObjectMapper objectMapper() {
+            return new ObjectMapper()
+                .registerModule(new Jdk8Module())
+                .registerModule(new ParameterNamesModule(JsonCreator.Mode.PROPERTIES))
+                .registerModule(new JavaTimeModule()).disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/ccd/client/model/CaseDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/client/model/CaseDetails.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.ccd.client.model;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -18,10 +17,8 @@ public class CaseDetails {
     @JsonProperty("case_type_id")
     private String caseTypeId;
     @JsonProperty("created_date")
-    @JsonFormat(pattern = "yyyy-MM-ddTHH:mm:ss.SSS")
     private LocalDateTime createdDate;
     @JsonProperty("last_modified")
-    @JsonFormat(pattern = "yyyy-MM-ddTHH:mm:ss.SSS")
     private LocalDateTime lastModified;
     private String state;
     @JsonProperty("locked_by_user_id")


### PR DESCRIPTION
This PR adds the custom object mapper for the Feign decoder, in order to deserialise LocalDateTime correctly.