### PR TITLE
ROC-2984: Add configuration class to toggle on or off

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.0.10'
+version '1.1.0'
 
 checkstyle {
     maxWarnings = 0

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.0.9'
+version '1.0.10'
 
 checkstyle {
     maxWarnings = 0

--- a/src/main/java/uk/gov/hmcts/reform/ccd/client/CoreCaseDataClientAutoConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/client/CoreCaseDataClientAutoConfiguration.java
@@ -8,11 +8,11 @@ import uk.gov.hmcts.reform.ccd.client.healthcheck.CoreCaseDataHealthIndicator;
 
 @Configuration
 @EnableFeignClients(basePackages = "uk.gov.hmcts.reform.ccd.client")
-public class CoreCaseDataClientConfiguration {
+public class CoreCaseDataClientAutoConfiguration {
 
     @Bean
     @ConditionalOnProperty(prefix = "core_case_data", name = "api.url")
-    public CoreCaseDataHealthIndicator coreCaseDataHealthIndicator(CoreCaseDataApi coreCaseDataApi) {
+    public CoreCaseDataHealthIndicator healthIndicator(CoreCaseDataApi coreCaseDataApi) {
         return new CoreCaseDataHealthIndicator(coreCaseDataApi);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/ccd/client/CoreCaseDataClientConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/client/CoreCaseDataClientConfiguration.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.ccd.client;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.netflix.feign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.hmcts.reform.ccd.client.healthcheck.CoreCaseDataHealthIndicator;
+
+@Configuration
+@EnableFeignClients(basePackages = "uk.gov.hmcts.reform.ccd.client")
+public class CoreCaseDataClientConfiguration {
+
+    @Bean
+    @ConditionalOnProperty(prefix = "core_case_data", name = "api.url")
+    public CoreCaseDataHealthIndicator coreCaseDataHealthIndicator(CoreCaseDataApi coreCaseDataApi) {
+        return new CoreCaseDataHealthIndicator(coreCaseDataApi);
+    }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  uk.gov.hmcts.reform.ccd.client.CoreCaseDataClientConfiguration
+  uk.gov.hmcts.reform.ccd.client.CoreCaseDataClientAutoConfiguration

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  uk.gov.hmcts.reform.ccd.client.healthcheck.CoreCaseDataHealthIndicator
+  uk.gov.hmcts.reform.ccd.client.CoreCaseDataClientConfiguration


### PR DESCRIPTION
This PR adds the `Configuration` class to conditionally enable health check indicator. 