### PR TITLE
Use autoconfiguration to initialise components

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@ This is a client library for interacting with the core case data store applicati
 - [JDK 8](https://www.oracle.com/java)
 - [Docker](https://www.docker.com)
 
-### Building
+## Usage
+
+Just include the library as your dependency and you will be to use the client class. Health check for CCD service is provided as well.
+
+Components provided by this library will get automatically configured in a Spring context if `core_case_data.api.url` configuration property is defined and does not equal `false`. 
+
+## Building
 
 The project uses [Gradle](https://gradle.org) as a build tool but you don't have install it locally since there is a
 `./gradlew` wrapper script.  

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '1.1.0'
+version '1.1.1'
 
 checkstyle {
     maxWarnings = 0

--- a/src/main/java/uk/gov/hmcts/reform/ccd/client/CoreCaseDataApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/client/CoreCaseDataApi.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import feign.codec.Decoder;
 import feign.jackson.JacksonDecoder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.netflix.feign.FeignClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
@@ -67,17 +68,9 @@ public interface CoreCaseDataApi {
     class CoreCaseDataConfiguration {
         @Bean
         @Primary
-        @Scope("prototype")
-        Decoder feignDecoder() {
-            return new JacksonDecoder(objectMapper());
-        }
-
-        @Bean
-        public ObjectMapper objectMapper() {
-            return new ObjectMapper()
-                .registerModule(new Jdk8Module())
-                .registerModule(new JavaTimeModule()).disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        Decoder feignDecoder(ObjectMapper objectMapper) {
+            return new JacksonDecoder(objectMapper);
         }
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/ccd/client/CoreCaseDataApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/client/CoreCaseDataApi.java
@@ -1,16 +1,11 @@
 package uk.gov.hmcts.reform.ccd.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import feign.codec.Decoder;
 import feign.jackson.JacksonDecoder;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.netflix.feign.FeignClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
-import org.springframework.context.annotation.Scope;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;

--- a/src/main/java/uk/gov/hmcts/reform/ccd/client/CoreCaseDataClientAutoConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/client/CoreCaseDataClientAutoConfiguration.java
@@ -12,7 +12,7 @@ import uk.gov.hmcts.reform.ccd.client.healthcheck.CoreCaseDataHealthIndicator;
 public class CoreCaseDataClientAutoConfiguration {
 
     @Bean
-    public CoreCaseDataHealthIndicator healthIndicator(CoreCaseDataApi coreCaseDataApi) {
+    public CoreCaseDataHealthIndicator coreCaseData(CoreCaseDataApi coreCaseDataApi) {
         return new CoreCaseDataHealthIndicator(coreCaseDataApi);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/ccd/client/CoreCaseDataClientAutoConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/client/CoreCaseDataClientAutoConfiguration.java
@@ -7,12 +7,13 @@ import org.springframework.context.annotation.Configuration;
 import uk.gov.hmcts.reform.ccd.client.healthcheck.CoreCaseDataHealthIndicator;
 
 @Configuration
+@ConditionalOnProperty(prefix = "core_case_data", name = "api.url")
 @EnableFeignClients(basePackages = "uk.gov.hmcts.reform.ccd.client")
 public class CoreCaseDataClientAutoConfiguration {
 
     @Bean
-    @ConditionalOnProperty(prefix = "core_case_data", name = "api.url")
     public CoreCaseDataHealthIndicator healthIndicator(CoreCaseDataApi coreCaseDataApi) {
         return new CoreCaseDataHealthIndicator(coreCaseDataApi);
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/ccd/client/healthcheck/CoreCaseDataHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/client/healthcheck/CoreCaseDataHealthIndicator.java
@@ -8,14 +8,12 @@ import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 
-@Component
 public class CoreCaseDataHealthIndicator implements HealthIndicator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CoreCaseDataHealthIndicator.class);
 
     private final CoreCaseDataApi coreCaseDataApi;
 
-    @Autowired
     public CoreCaseDataHealthIndicator(final CoreCaseDataApi coreCaseDataApi) {
         this.coreCaseDataApi = coreCaseDataApi;
     }
@@ -30,4 +28,5 @@ public class CoreCaseDataHealthIndicator implements HealthIndicator {
             return Health.down(ex).build();
         }
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/ccd/client/healthcheck/CoreCaseDataHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/client/healthcheck/CoreCaseDataHealthIndicator.java
@@ -2,10 +2,8 @@ package uk.gov.hmcts.reform.ccd.client.healthcheck;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
-import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 
 public class CoreCaseDataHealthIndicator implements HealthIndicator {

--- a/src/main/java/uk/gov/hmcts/reform/ccd/client/healthcheck/InternalHealth.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/client/healthcheck/InternalHealth.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.ccd.client.healthcheck;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.boot.actuate.health.Status;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -11,9 +10,9 @@ public class InternalHealth {
 
     @JsonCreator
     public InternalHealth(
-        @JsonProperty("status") Status status
+        String status
     ) {
-        this.status = status;
+        this.status = new Status(status);
     }
 
     public Status getStatus() {


### PR DESCRIPTION
This change makes sure that no CCD related components are being initialised if the CCD url configuration property is not provided.