### PR TITLE
Bump version to 4.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '4.1.2'
+version '4.1.3'
 
 checkstyle {
     maxWarnings = 0


### PR DESCRIPTION
Previous (4.1.2) release is based on the same commit as 4.1.1