### PR TITLE
Added json ignore to callback request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '4.3.0'
+version '4.3.1'
 
 checkstyle {
     maxWarnings = 0

--- a/src/main/java/uk/gov/hmcts/reform/ccd/client/model/CallbackRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/client/model/CallbackRequest.java
@@ -1,11 +1,13 @@
 package uk.gov.hmcts.reform.ccd.client.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CallbackRequest {
 
     @JsonProperty("case_details")


### PR DESCRIPTION
- In future CCD callback requests will have extra fields such as ignore_warning which will be sent. 

- Since we don't ignore unknown fields it will break the callback. 