### PR TITLE
Added value to experimental header as it is removed if it is null

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '4.5.0'
+version '4.6.0'
 
 checkstyle {
     maxWarnings = 0

--- a/src/main/java/uk/gov/hmcts/reform/ccd/client/CoreCaseDataApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/ccd/client/CoreCaseDataApi.java
@@ -30,7 +30,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 )
 public interface CoreCaseDataApi {
     String SERVICE_AUTHORIZATION = "ServiceAuthorization";
-    String EXPERIMENTAL = "experimental=";
+    String EXPERIMENTAL = "experimental=true";
 
     @RequestMapping(
             method = RequestMethod.GET,

--- a/src/test/java/uk/gov/hmcts/reform/ccd/client/CcdClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/ccd/client/CcdClientTest.java
@@ -68,7 +68,7 @@ class CcdClientTest {
         stubFor(get(urlEqualTo("/cases/1234"))
                 .withHeader("ServiceAuthorization", equalTo("s2sAuth"))
                 .withHeader(AUTHORIZATION, equalTo("UserToken"))
-                .withHeader("experimental", equalTo("")
+                .withHeader("experimental", equalTo("true")
                 )
                 .willReturn(okJson(loadFile("v2Case.json")))
         );


### PR DESCRIPTION

### Change description ###

- Newer versions of Feign clients(feign-core > 10.0.0) needs a value for header else it removes it .

- Results in 404 if the experimental header is removed. Lower versions of Feign(<10.0.0) doesn't removes the header if the value is null.

- To preserve the header we need to provide a value for the header key.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```